### PR TITLE
Add grid gap and layout spacing variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@flickerbox/fabric",
-  "version": "21.0.39",
+  "version": "21.0.40",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flickerbox/fabric",
-  "version": "21.0.39",
+  "version": "21.0.40",
   "description": "An unopinionated framework that works within your existing workflow to cut down on repetitive tasks.",
   "scripts": {
     "production": "webpack --config=config/webpack.prod.js --info-verbosity verbose --progress && npm run delete-maps",

--- a/src/base-placeholders/_root.scss
+++ b/src/base-placeholders/_root.scss
@@ -74,6 +74,13 @@
 		}
 	}
 
+	@each $name, $value in $grid-gaps {
+		@if $name == 'normal' {
+			@include responsive-property('--gap', $value);
+		}
+		@include responsive-property('--gap-#{$name}', $value);
+	}
+
 	$excluded-spacing: (
 		'0',
 		'none',
@@ -83,5 +90,9 @@
 		@if not list.index($excluded-spacing, $name) {
 			@include responsive-property('--spacing-#{$name}', $value);
 		}
+	}
+
+	@for $i from 1 through $layout-spacing-max-units {
+		@include responsive-property('--#{$i}x', _(#{$i}x));
 	}
 }

--- a/src/variables/_layout.scss
+++ b/src/variables/_layout.scss
@@ -14,5 +14,8 @@ $layout-padding: 3x                                            !default;
 /// @name layout-spacing
 $layout-spacing: 8px                                           !default;
 
+/// @name layout-spacing-max-units
+$layout-spacing-max-units: 30                                  !default;
+
 /// @name layout-width
 $layout-width: 1080px                                          !default;


### PR DESCRIPTION
# Description

Adds grid and layout css variables for use in this format:

```
gap: var(--gap-normal);
padding: var(--5x);
```

## Type of change

Please describe the type of change.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] I have followed the guidelines in the contributing doc
- [x] I have checked there aren't other open [Pull Requests](../../../pulls) for the same update or change
- [x] I have added an explanation of what my changes do and why I'd like to incorporate them
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I had fun writing this code
