### PR TITLE
Migrate font mixins to use css variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@flickerbox/fabric",
-  "version": "21.0.41",
+  "version": "21.0.42",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@flickerbox/fabric",
-  "version": "21.0.40",
+  "version": "21.0.41",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flickerbox/fabric",
-  "version": "21.0.41",
+  "version": "21.0.42",
   "description": "An unopinionated framework that works within your existing workflow to cut down on repetitive tasks.",
   "scripts": {
     "production": "webpack --config=config/webpack.prod.js --info-verbosity verbose --progress && npm run delete-maps",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flickerbox/fabric",
-  "version": "21.0.40",
+  "version": "21.0.41",
   "description": "An unopinionated framework that works within your existing workflow to cut down on repetitive tasks.",
   "scripts": {
     "production": "webpack --config=config/webpack.prod.js --info-verbosity verbose --progress && npm run delete-maps",

--- a/src/base-placeholders/_root.scss
+++ b/src/base-placeholders/_root.scss
@@ -45,33 +45,20 @@
 	--font-family-sans-serif: #{$font-family--sans-serif};
 	--font-family-serif: #{$font-family--serif};
 
-	$excluded-font-sizes: (
-		'base',
-		'button',
-	);
-
 	@each $name, $value in $font-size {
-		@if not list.index($excluded-font-sizes, $name) {
-			@include responsive-property('--font-size-#{$name}', $value);
-		}
+		@include responsive-property('--font-size-#{$name}', $value);
 	}
 
 	@each $name, $value in $font-weight {
-		@if not list.index($excluded-font-sizes, $name) {
-			@include responsive-property('--font-weight-#{$name}', $value);
-		}
+		@include responsive-property('--font-weight-#{$name}', $value);
 	}
 
 	@each $name, $value in $letter-spacing {
-		@if not list.index($excluded-font-sizes, $name) {
-			@include responsive-property('--letter-spacing-#{$name}', $value);
-		}
+		@include responsive-property('--letter-spacing-#{$name}', $value);
 	}
 
 	@each $name, $value in $line-height {
-		@if not list.index($excluded-font-sizes, $name) {
-			@include responsive-property('--line-height-#{$name}', $value);
-		}
+		@include responsive-property('--line-height-#{$name}', $value);
 	}
 
 	@each $name, $value in $grid-gaps {

--- a/src/mixins/_font-size.scss
+++ b/src/mixins/_font-size.scss
@@ -3,24 +3,12 @@
 ///
 /// @group Mixins
 /// @param {String} $key - Key defined in $font-size map
-/// @param {String} $breakpoint - If defined as a sub value, will only apply the specific breakpoint value
 ///
-@mixin font-size($_value, $_size: '') {
+@mixin font-size($key) {
 
-	@if type-of($_value) == string and index(map-keys($font-size), $_value) {
+	@if type-of($key) == string and index(map-keys($font-size), $key) {
 
-		$_font-size: get-font-size($_value, $_size);
-
-		@if type-of($_font-size) == 'map' {
-
-			$first: true;
-			@include responsive-property('font-size', $_font-size);
-
-		} @else {
-
-			font-size: #{$_font-size};
-
-		}
+		font-size: var(--font-size-#{$key});
 
 	}
 

--- a/src/mixins/_font-weight.scss
+++ b/src/mixins/_font-weight.scss
@@ -3,26 +3,13 @@
 ///
 /// @group Mixins
 /// @param {String} $key - Key defined in $font-weight map
-/// @param {String} $breakpoint - If defined as a sub value, will only apply the specific breakpoint value
 ///
-@mixin font-weight($_value, $_size: '') {
+@mixin font-weight($key) {
 
-	@if type-of($_value) == string and index(map-keys($font-weight), $_value) {
+	@if type-of($key) == string and index(map-keys($font-weight), $key) {
 
-		$_font-weight: get-font-weight($_value, $_size);
-
-		@if type-of($_font-weight) == 'map' {
-
-			$first: true;
-			@include responsive-property('font-variation-settings', $_font-weight, "'wght' %s");
-			@include responsive-property('font-weight', $_font-weight);
-
-		} @else {
-
-			font-variation-settings: 'wght' #{$_font-weight};
-			font-weight: #{$_font-weight};
-
-		}
+		font-variation-settings: 'wght' var(--font-weight-#{$key});
+		font-weight: var(--font-weight-#{$key});
 
 	}
 

--- a/src/mixins/_font.scss
+++ b/src/mixins/_font.scss
@@ -3,14 +3,13 @@
 ///
 /// @group Mixins
 /// @param {String} $key - Key defined in font property maps
-/// @param {String} $breakpoint - If defined as a sub value, will only apply the specific breakpoint value
 ///
-@mixin font($_value, $_size: '') {
+@mixin font($key) {
 
-	@include font-size($_value, $_size);
-	@include font-weight($_value, $_size);
-	@include letter-spacing($_value, $_size);
-	@include line-height($_value, $_size);
-	@include text-transform($_value, $_size);
+	@include font-size($key);
+	@include font-weight($key);
+	@include letter-spacing($key);
+	@include line-height($key);
+	@include text-transform($key);
 
 }

--- a/src/mixins/_letter-spacing.scss
+++ b/src/mixins/_letter-spacing.scss
@@ -3,24 +3,12 @@
 ///
 /// @group Mixins
 /// @param {String} $key - Key defined in $letter-spacing map
-/// @param {String} $breakpoint - If defined as a sub value, will only apply the specific breakpoint value
 ///
-@mixin letter-spacing($_value, $_size: '') {
+@mixin letter-spacing($key) {
 
-	@if type-of($_value) == string and index(map-keys($letter-spacing), $_value) {
+	@if type-of($key) == string and index(map-keys($letter-spacing), $key) {
 
-		$_letter-spacing: get-letter-spacing($_value, $_size);
-
-		@if type-of($_letter-spacing) == 'map' {
-
-			$first: true;
-			@include responsive-property('letter-spacing', $_letter-spacing);
-
-		} @else {
-
-			letter-spacing: #{$_letter-spacing};
-
-		}
+		letter-spacing: var(--letter-spacing-#{$key});
 
 	}
 

--- a/src/mixins/_line-height.scss
+++ b/src/mixins/_line-height.scss
@@ -1,39 +1,33 @@
-@use 'sass:math';
+///
+/// Responsively sets line-height based on key in $line-height map
+///
+/// @group Mixins
+/// @param {String} $key - Key defined in $line-height map
+///
+@mixin line-height($key) {
 
-/// Sets line height responsively
-/// @name line-height
-/// @group Fabric Mixins
-/// @access public
-/// @param {string} $_value [] - Set the line height type
-/// @param {string} $_size [''] -
-/// @require {function} SassCore::type-of
-/// @require {function} SassCore::index
-/// @require {function} SassCore::map-keys
-/// @require {function} SassCore::nth
-/// @require {function} get-line-height
-/// @require {function} responsive-property
-/// @require {function} get-font-size
+	@if type-of($key) == string and index(map-keys($line-height), $key) {
 
-@mixin line-height($_value, $_size: '') {
+		$line-height: get-line-height($key);
 
-	@if type-of($_value) == string and index(map-keys($line-height), $_value) {
+		@if type-of($line-height) == 'map' {
 
-		$_line-height: get-line-height($_value, $_size);
-
-		@if type-of($_line-height) == 'map' {
-
-			$first: true;
-			@include responsive-property('line-height', $_line-height);
+			line-height: var(--line-height-#{$key});
 
 		} @else {
 
-			$_font-size: get-font-size($_value);
+			$font-size: get-font-size($key);
 
-			@if type-of($_font-size) == 'map' {
-				$_font-size: get-font-size($_value, nth(map-keys($_font-size), 1));
+			@if type-of($font-size) == 'map' {
+
+				$font-size: get-font-size($key, nth(map-keys($font-size), 1));
+				line-height: calc(var(--line-height-#{$key}) / $font-size);
+
+			} @else {
+
+				line-height: calc(var(--line-height-#{$key}) / var(--font-size-#{$key}));
+
 			}
-
-			line-height: math.div($_line-height, $_font-size);
 
 		}
 

--- a/src/mixins/_text-transform.scss
+++ b/src/mixins/_text-transform.scss
@@ -1,31 +1,14 @@
-/// Sets text transform responsively
-/// @name text-transform
-/// @group Fabric Mixins
-/// @access public
-/// @param {string} $_value [] - Set the text transform type
-/// @param {string} $_size [''] -
-/// @require {function} SassCore::type-of
-/// @require {function} SassCore::index
-/// @require {function} SassCore::map-keys
-/// @require {function} get-text-transform
-/// @require {function} responsive-property
+///
+/// Responsively sets text-transform based on key in $text-transform map
+///
+/// @group Mixins
+/// @param {String} $key - Key defined in $text-transform map
+///
+@mixin text-transform($key) {
 
-@mixin text-transform($_value, $_size: '') {
+	@if type-of($key) == string and index(map-keys($text-transform), $key) {
 
-	@if type-of($_value) == string and index(map-keys($text-transform), $_value) {
-
-		$_text-transform: get-text-transform($_value, $_size);
-
-		@if type-of($_text-transform) == 'map' {
-
-			$first: true;
-			@include responsive-property('text-transform', $_text-transform);
-
-		} @else {
-
-			text-transform: #{$_text-transform};
-
-		}
+		text-transform: var(--text-transform-#{$key});
 
 	}
 


### PR DESCRIPTION
# Description

This update migrates the font mixins to utilize CSS variables, continuing in line with recent changes.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] I have followed the guidelines in the contributing doc
- [x]  I have checked there aren't other open [Pull Requests](../../../pulls) for the same update or change
- [x] I have added an explanation of what my changes do and why I'd like to incorporate them
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I had fun writing this code
