### PR TITLE
Enable h1-h6 font utility classes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@flickerbox/fabric",
-  "version": "21.0.45",
+  "version": "21.0.46",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flickerbox/fabric",
-  "version": "21.0.45",
+  "version": "21.0.46",
   "description": "An unopinionated framework that works within your existing workflow to cut down on repetitive tasks.",
   "scripts": {
     "production": "webpack --config=config/webpack.prod.js --info-verbosity verbose --progress && npm run delete-maps",

--- a/src/utility-placeholders/_font.scss
+++ b/src/utility-placeholders/_font.scss
@@ -3,12 +3,6 @@
 
 $excluded-font-sizes: (
 	'base',
-	'h1',
-	'h2',
-	'h3',
-	'h4',
-	'h5',
-	'h6',
 	'button',
 );
 

--- a/src/utility/_font.scss
+++ b/src/utility/_font.scss
@@ -3,12 +3,6 @@
 
 $excluded-font-sizes: (
 	'base',
-	'h1',
-	'h2',
-	'h3',
-	'h4',
-	'h5',
-	'h6',
 	'button',
 );
 


### PR DESCRIPTION
# Description

Enables standard `font-` format for h1-h6 utility classes.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have followed the guidelines in the contributing doc
- [x] I have checked there aren't other open [Pull Requests](../../../pulls) for the same update or change
- [x] I have added an explanation of what my changes do and why I'd like to incorporate them
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I had fun writing this code
